### PR TITLE
feat(profiles): implement profiles CRUD endpoints

### DIFF
--- a/models/profile.js
+++ b/models/profile.js
@@ -14,10 +14,10 @@ export const Profile = sequelize.define(
       type: DataTypes.INTEGER,
       allowNull: false,
       references: {
-        model: User, // reference the Users table
+        model: User,
         key: 'user_id',
       },
-      onDelete: 'CASCADE', // matches your SQL constraint
+      onDelete: 'CASCADE',
     },
     specialization: {
       type: DataTypes.STRING(100),

--- a/routes/profiles/controllers.js
+++ b/routes/profiles/controllers.js
@@ -1,0 +1,89 @@
+import { Profile } from '../../models/profile.js'
+import { updateProfileSchema } from '../../schemas/profiles.js'
+import { profileSchema } from '../../schemas/profiles.js'
+
+// Get all Profiles
+export const getAllProfiles = async (_, res) => {
+  try {
+    const result = await Profile.findAll()
+    return res.status(200).json(result)
+  } catch (error) {
+    if (error instanceof Error) {
+      return res.status(400).json({ mesage: error.message })
+    }
+    return res.status(500).json({ message: 'An error has occured' })
+  }
+}
+
+// Get all Profiles
+export const getOneProfile = async (req, res) => {
+  try {
+    const id = parseInt(req.params.id)
+    const result = await Profile.findByPk(id)
+    return res.status(200).json(result)
+  } catch (error) {
+    if (error instanceof Error) {
+      return res.status(400).json({ mesage: error.message })
+    }
+    return res.status(500).json({ message: 'An error has occured' })
+  }
+}
+
+// Create profile
+export const createProfile = async (req, res) => {
+  try {
+    const body = req.body
+    const profile = await profileSchema.validateAsync(body)
+    const result = await Profile.create(profile)
+    return res.status(200).json(result)
+  } catch (error) {
+    if (error instanceof Error) {
+      return res.status(400).json({ mesage: error.message })
+    }
+    return res.status(500).json({ message: 'An error has occured' })
+  }
+}
+
+// Update profile
+export const updateProfile = async (req, res) => {
+  try {
+    const id = parseInt(req.params.id)
+    const body = req.body
+    const profileUpdate = await updateProfileSchema.validateAsync(body)
+
+    const result = await Profile.findOne({ where: { profile_id: id } })
+    if (!result) {
+      return res.status(404).json({ message: 'Not found' })
+    }
+
+    await Profile.update(profileUpdate, {
+      where: {
+        profile_id: id,
+      },
+    })
+
+    return res.status(200).json({ message: 'Profile updated' })
+  } catch (error) {
+    if (error instanceof Error) {
+      return res.status(400).json({ mesage: error.message })
+    }
+    return res.status(500).json({ message: 'An error has occured' })
+  }
+}
+
+// Delete profile
+export const deleteProfile = async (req, res) => {
+  try {
+    const id = parseInt(req.params.id)
+    const result = await Profile.destroy({ where: { profile_id: id } })
+    if (!result) {
+      return res.status(404).json({ message: 'Not found' })
+    }
+    return res.status(200).json(result)
+  } catch (error) {
+    if (error instanceof Error) {
+      return res.status(400).json({ mesage: error.message })
+    }
+    return res.status(500).json({ message: 'An error has occured' })
+  }
+}

--- a/routes/profiles/routes.js
+++ b/routes/profiles/routes.js
@@ -1,0 +1,25 @@
+import { Router } from 'express'
+import {
+  createProfile,
+  getAllProfiles,
+  getOneProfile,
+  deleteProfile,
+  updateProfile,
+} from './controllers.js'
+
+export const router = Router()
+
+// Get profiles
+router.get('/profiles', getAllProfiles)
+
+// Get one user
+router.get('/profiles/:id', getOneProfile)
+
+// Create user
+router.post('/profiles', createProfile)
+
+// Delete user
+router.delete('/profiles/:id', deleteProfile)
+
+// Update user
+router.put('/profiles/:id', updateProfile)

--- a/schemas/profiles.js
+++ b/schemas/profiles.js
@@ -1,0 +1,70 @@
+import Joi from 'joi'
+
+export const profileSchema = Joi.object({
+  user_id: Joi.number().integer().required().messages({
+    'number.base': 'User ID must be a number.',
+    'number.integer': 'User ID must be an integer.',
+    'any.required': 'User ID is required.',
+  }),
+
+  specialization: Joi.string().max(100).required().messages({
+    'string.base': 'Specialization must be text.',
+    'string.empty': 'Please provide your specialization.',
+    'string.max': 'Specialization cannot exceed 100 characters.',
+    'any.required': 'Specialization is required.',
+  }),
+
+  experience_years: Joi.number().integer().min(0).required().messages({
+    'number.base': 'Experience must be a number.',
+    'number.integer': 'Experience must be an integer.',
+    'number.min': 'Experience years cannot be negative.',
+    'any.required': 'Experience years are required.',
+  }),
+
+  bio: Joi.string().required().messages({
+    'string.base': 'Bio must be text.',
+    'string.empty': 'Please provide a bio.',
+    'any.required': 'Bio is required.',
+  }),
+  profile_photo_url: Joi.string().uri().allow(null, '').messages({
+    'string.base': 'Profile photo URL must be text.',
+    'string.uri': 'Profile photo URL must be a valid URI.',
+  }),
+  location: Joi.string().max(100).allow(null, '').messages({
+    'string.base': 'Location must be text.',
+    'string.max': 'Location cannot exceed 100 characters.',
+  }),
+})
+
+export const updateProfileSchema = Joi.object({
+  specialization: Joi.string().max(100).messages({
+    'string.base': 'Specialization must be text.',
+    'string.max': 'Specialization cannot exceed 100 characters.',
+  }),
+
+  experience_years: Joi.number().integer().min(0).messages({
+    'number.base': 'Experience must be a number.',
+    'number.integer': 'Experience must be an integer.',
+    'number.min': 'Experience years cannot be negative.',
+  }),
+
+  bio: Joi.string().messages({
+    'string.base': 'Bio must be text.',
+  }),
+
+  rating_avg: Joi.number().min(0).max(5).messages({
+    'number.base': 'Rating must be a number.',
+    'number.min': 'Rating cannot be less than 0.',
+    'number.max': 'Rating cannot be greater than 5.',
+  }),
+
+  profile_photo_url: Joi.string().uri().allow(null, '').messages({
+    'string.base': 'Profile photo URL must be text.',
+    'string.uri': 'Profile photo URL must be a valid URI.',
+  }),
+
+  location: Joi.string().max(100).allow(null, '').messages({
+    'string.base': 'Location must be text.',
+    'string.max': 'Location cannot exceed 100 characters.',
+  }),
+}).min(1)

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 import { sequelize } from './connection/db.js'
 import { router as users } from './routes/users/routes.js'
+import { router as profiles } from './routes/profiles/routes.js'
 import { router as login } from './routes/auth/login.js'
 import morgan from 'morgan'
 
@@ -40,6 +41,7 @@ app.use(express.json())
 app.use(cors())
 app.use(express.static(path.join(__dirname, 'public')))
 app.use('/api', users)
+app.use('/api', profiles)
 app.use(login)
 
 app.listen(PORT, () => {


### PR DESCRIPTION
This commit introduces a complete set of RESTful endpoints for managing user profiles.

- Adds controllers for creating, reading, updating, and deleting profiles.
- Defines Joi validation schemas for profile creation and updates to ensure data integrity.
- Establishes the API routes in `routes/profiles/routes.js` and integrates them into the main Express server.

The following endpoints are now available:
- GET /api/profiles
- GET /api/profiles/:id
- POST /api/profiles
- PUT /api/profiles/:id
- DELETE /api/profiles/:id

## Summary by Sourcery

Add CRUD API support for user profiles and integrate it into the main Express server.

New Features:
- Expose REST endpoints for listing, retrieving, creating, updating, and deleting profiles under /api/profiles.
- Introduce Joi-based validation schemas for profile creation and updates to enforce data integrity.

Enhancements:
- Wire the profiles router into the main API and slightly tidy the Profile model association metadata.