### PR TITLE
feat(profiles): display recent user profiles on homepage

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,9 +8,8 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@hookform/resolvers": "^5.2.2",
         "axios": "^1.13.2",
-        "jwt-decode": "^4.0.0",
+        "md5": "^2.3.0",
         "react": "^19.2.0",
         "react-bootstrap": "^2.10.10",
         "react-dom": "^19.2.0",
@@ -18,7 +17,6 @@
         "react-icons": "^5.5.0",
         "react-jwt": "^2.0.0",
         "react-router-dom": "^7.9.6",
-        "yup": "^1.7.1",
         "zustand": "^5.0.8"
       },
       "devDependencies": {
@@ -925,18 +923,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@hookform/resolvers": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
-      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/utils": "^0.3.0"
-      },
-      "peerDependencies": {
-        "react-hook-form": "^7.55.0"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1433,12 +1419,6 @@
         "win32"
       ]
     },
-    "node_modules/@standard-schema/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
-      "license": "MIT"
-    },
     "node_modules/@swc/helpers": {
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
@@ -1774,6 +1754,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
@@ -1852,6 +1841,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/csstype": {
@@ -2575,6 +2573,12 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2671,15 +2675,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jwt-decode": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
-      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2756,6 +2751,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/mime-db": {
@@ -3024,12 +3030,6 @@
         "react": ">=0.14.0"
       }
     },
-    "node_modules/property-expr": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
-      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
-      "license": "MIT"
-    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3105,7 +3105,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.66.1.tgz",
       "integrity": "sha512-2KnjpgG2Rhbi+CIiIBQQ9Df6sMGH5ExNyFl4Hw9qO7pIqMBR8Bvu9RQyjl3JM4vehzCh9soiNUM/xYMswb2EiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3350,12 +3349,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tiny-case": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
-      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
-      "license": "MIT"
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3372,12 +3365,6 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
-    },
-    "node_modules/toposort": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
-      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -3396,18 +3383,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/uncontrollable": {
@@ -3595,18 +3570,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yup": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.1.tgz",
-      "integrity": "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==",
-      "license": "MIT",
-      "dependencies": {
-        "property-expr": "^2.0.5",
-        "tiny-case": "^1.0.3",
-        "toposort": "^2.0.2",
-        "type-fest": "^2.19.0"
       }
     },
     "node_modules/zod": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,9 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@hookform/resolvers": "^5.2.2",
     "axios": "^1.13.2",
-    "jwt-decode": "^4.0.0",
+    "md5": "^2.3.0",
     "react": "^19.2.0",
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.2.0",
@@ -20,7 +19,6 @@
     "react-icons": "^5.5.0",
     "react-jwt": "^2.0.0",
     "react-router-dom": "^7.9.6",
-    "yup": "^1.7.1",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom'
 import { Layout } from './components/Layout'
-import { Homepage } from './pages/Homepage'
+import { Homepage } from './pages/homepage/Homepage'
 import Signup from './pages/Signup'
 import LoginPage from './pages/LoginPage'
 import { useAuthStore } from './store/useAuthStore'

--- a/frontend/src/hooks/useFetchUsers.js
+++ b/frontend/src/hooks/useFetchUsers.js
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react'
+import { api as axios } from '../api'
+import { isAxiosError } from 'axios'
+
+export const useFetchUsers = () => {
+  const [data, setData] = useState([])
+  const [error, setError] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    getUsers()
+  }, [])
+
+  const getUsers = async () => {
+    try {
+      const response = await axios.get('/users')
+      const usersData = await response.data
+      setData(usersData)
+    } catch (error) {
+      if (isAxiosError(error)) {
+        const message = await error.response.data.message
+        console.log(message || 'An error has occured')
+        setError(message || 'An error has occured')
+        return
+      }
+      console.log(error.message || 'An error has occured')
+      setError(error.message || 'An error has occured')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return { data, error, loading }
+}

--- a/frontend/src/pages/homepage/Hero.jsx
+++ b/frontend/src/pages/homepage/Hero.jsx
@@ -3,11 +3,11 @@ import Container from 'react-bootstrap/esm/Container'
 import { Link } from 'react-router-dom'
 import './HomePage.css'
 
-const Hero = () => {
+export const Hero = () => {
   return (
     <Stack
       className="hero-container bg-secondary-subtle justify-content-center"
-      style={{ maxHeight: 500 }}
+      style={{ maxHeight: 500, minHeight: 500 }}
     >
       <Container>
         <Stack className="gap-3">
@@ -27,14 +27,6 @@ const Hero = () => {
           </Link>
         </Stack>
       </Container>
-    </Stack>
-  )
-}
-
-export const Homepage = () => {
-  return (
-    <Stack as="main">
-      <Hero />
     </Stack>
   )
 }

--- a/frontend/src/pages/homepage/HomePage.css
+++ b/frontend/src/pages/homepage/HomePage.css
@@ -1,5 +1,5 @@
 .hero-container {
-  background-image: url(../assets/images/hero-img.webp);
+  background-image: url(../../assets/images/hero-img.webp);
   background-size: cover;
   background-repeat: no-repeat;
   background-position: top;

--- a/frontend/src/pages/homepage/Homepage.jsx
+++ b/frontend/src/pages/homepage/Homepage.jsx
@@ -1,0 +1,15 @@
+import './HomePage.css'
+import Stack from 'react-bootstrap/esm/Stack'
+import { Hero } from './Hero'
+import { RecentProfiles } from './RecentProfiles'
+// import Container from 'react-bootstrap/esm/Container'
+//import { Link } from 'react-router-dom'
+
+export const Homepage = () => {
+  return (
+    <Stack as="main">
+      <Hero />
+      <RecentProfiles />
+    </Stack>
+  )
+}

--- a/frontend/src/pages/homepage/RecentProfiles.jsx
+++ b/frontend/src/pages/homepage/RecentProfiles.jsx
@@ -1,0 +1,61 @@
+import { useFetchUsers } from '../../hooks/useFetchUsers'
+import Stack from 'react-bootstrap/esm/Stack'
+import Container from 'react-bootstrap/esm/Container'
+import Button from 'react-bootstrap/esm/Button'
+import Card from 'react-bootstrap/esm/Card'
+import Row from 'react-bootstrap/esm/Row'
+import Col from 'react-bootstrap/esm/Col'
+import Badge from 'react-bootstrap/esm/Badge'
+import md5 from 'md5'
+
+const UserCard = ({ user }) => {
+  return (
+    <Col xs={12} sm={6} lg={4} xl={3} className="mb-4">
+      <Card>
+        <Card.Img variant="top" src={getGravatarUrl(user.email)} />
+        <Card.Body>
+          <Card.Title>
+            {user.name}{' '}
+            <Badge pill bg={user.role === 'lawyer' ? 'secondary' : 'primary'}>
+              {user.role}
+            </Badge>
+          </Card.Title>
+          <Card.Text>{user.Profile.bio}</Card.Text>
+        </Card.Body>
+        <Card.Footer>
+          <Button variant="primary" size="sm">
+            View Profile
+          </Button>
+        </Card.Footer>
+      </Card>
+    </Col>
+  )
+}
+
+function getGravatarUrl(email, size = 200) {
+  const hash = md5(email.trim().toLowerCase())
+  return `https://www.gravatar.com/avatar/${hash}?s=${size}&d=monsterid`
+}
+
+export const RecentProfiles = () => {
+  const { data, error, loading } = useFetchUsers()
+
+  if (error) return <p>{JSON.stringify(error)}</p>
+  if (loading) return <p>Loading...</p>
+
+  return (
+    <Stack className="recent-profiles py-5">
+      <Container>
+        <h2 className="text-center mb-5">Recent Profiles</h2>
+        <Row>
+          {data &&
+            data
+              .filter((user) => user.Profile)
+              .map((user) => {
+                return <UserCard key={user.user_id} user={user} />
+              })}
+        </Row>
+      </Container>
+    </Stack>
+  )
+}

--- a/routes/users/controllers.js
+++ b/routes/users/controllers.js
@@ -2,11 +2,13 @@ import { User } from '../../models/user.js'
 import bcrypt from 'bcryptjs'
 import { seedData } from '../../seeds/seedData.js'
 import { userSchema } from '../../schemas/users.js'
+import { Profile } from '../../models/profile.js'
 
 // Get all users
-export const getAllUsers = async (req, res) => {
+export const getAllUsers = async (_, res) => {
   try {
     const result = await User.findAll({
+      include: [{ model: Profile }],
       attributes: ['user_id', 'name', 'email', 'role', 'created_at'],
     })
     return res.status(200).json(result)
@@ -18,7 +20,23 @@ export const getAllUsers = async (req, res) => {
   }
 }
 
-// Get all users
+// Get users with profiles
+export const getUsersWithProfiles = async (_, res) => {
+  try {
+    const result = await User.findAll({
+      include: [{ model: Profile }],
+      attributes: ['user_id', 'name', 'email', 'role', 'created_at'],
+    })
+    return res.status(200).json(result)
+  } catch (error) {
+    if (error instanceof Error) {
+      return res.status(400).json({ message: error.message })
+    }
+    return res.status(500).json({ message: 'An error has occured' })
+  }
+}
+
+// Get users
 export const getOneUser = async (req, res) => {
   try {
     const id = parseInt(req.params.id)

--- a/routes/users/routes.js
+++ b/routes/users/routes.js
@@ -5,12 +5,16 @@ import {
   getOneUser,
   deleteUser,
   updateUser,
+  getUsersWithProfiles,
 } from './controllers.js'
 
 export const router = Router()
 
 // Get users
 router.get('/users', getAllUsers)
+
+// Get users with profiles
+router.get('/users-with-profiles', getUsersWithProfiles)
 
 // Get one user
 router.get('/users/:id', getOneUser)


### PR DESCRIPTION
Adds a new 'Recent Profiles' section to the homepage to showcase users.

This feature includes:
- A 'RecentProfiles' component to fetch and display user cards.
- A 'useFetchUsers' custom hook to handle the logic of fetching user data.
- Integration of Gravatar for user avatars, using the 'md5' package to hash emails.
- An update to the backend '/users' endpoint to include profile information in the query, ensuring all necessary data is available.
- A refactor of the homepage components, organizing them into a dedicated 'src/pages/homepage' directory.
- Removal of unused dependencies such as 'yup', 'jwt-decode', and '@hookform/resolvers' to clean up the project.

## Summary by Sourcery

Add a Recent Profiles section to the homepage that showcases users with profile information and Gravatar avatars, backed by an updated users API and frontend refactor.

New Features:
- Introduce a RecentProfiles homepage section displaying user profile cards with avatars, roles, and bios.
- Add a useFetchUsers custom hook to retrieve user data from the backend.
- Expose a /users-with-profiles API route that returns users along with their associated profile data.

Enhancements:
- Refactor homepage layout into a dedicated src/pages/homepage directory with separate Hero and Homepage components.
- Ensure hero section has a fixed minimum height for consistent layout across the homepage.
- Update homepage hero background image path to reflect the new directory structure.
- Include Profile model data in the existing users query for richer user information.
- Integrate Gravatar-based avatar URLs for user cards based on email addresses.

Build:
- Add md5 dependency for computing Gravatar hashes and remove unused yup, jwt-decode, and @hookform/resolvers packages.