### PR TITLE
feat(reviews): add reviews CRUD endpoints

### DIFF
--- a/routes/reviews/controllers.js
+++ b/routes/reviews/controllers.js
@@ -1,0 +1,91 @@
+import { Review } from '../../models/review.js'
+import {
+  createReviewSchema,
+  updateReviewSchema,
+} from '../../schemas/reviews.js'
+
+// Get all Reviews
+export const getAllReviews = async (_, res) => {
+  try {
+    const result = await Review.findAll()
+    return res.status(200).json(result)
+  } catch (error) {
+    if (error instanceof Error) {
+      return res.status(400).json({ message: error.message })
+    }
+    return res.status(500).json({ message: 'An error has occured' })
+  }
+}
+
+// Get all Reviews
+export const getOneReview = async (req, res) => {
+  try {
+    const id = parseInt(req.params.id)
+    const result = await Review.findByPk(id)
+    return res.status(200).json(result)
+  } catch (error) {
+    if (error instanceof Error) {
+      return res.status(400).json({ message: error.message })
+    }
+    return res.status(500).json({ message: 'An error has occured' })
+  }
+}
+
+// Create Review
+export const createReview = async (req, res) => {
+  try {
+    const body = req.body
+    const review = await createReviewSchema.validateAsync(body)
+    const result = await Review.create(review)
+    return res.status(200).json(result)
+  } catch (error) {
+    if (error instanceof Error) {
+      return res.status(400).json({ message: error.message })
+    }
+    return res.status(500).json({ message: 'An error has occured' })
+  }
+}
+
+// Update Review
+export const updateReview = async (req, res) => {
+  try {
+    const id = parseInt(req.params.id)
+    const body = req.body
+    const reviewUpdate = await updateReviewSchema.validateAsync(body)
+
+    const result = await Review.findOne({ where: { review_id: id } })
+    if (!result) {
+      return res.status(404).json({ message: 'Not found' })
+    }
+
+    await Review.update(reviewUpdate, {
+      where: {
+        review_id: id,
+      },
+    })
+
+    return res.status(200).json({ message: 'Review updated' })
+  } catch (error) {
+    if (error instanceof Error) {
+      return res.status(400).json({ message: error.message })
+    }
+    return res.status(500).json({ message: 'An error has occured' })
+  }
+}
+
+// Delete Review
+export const deleteReview = async (req, res) => {
+  try {
+    const id = parseInt(req.params.id)
+    const result = await Review.destroy({ where: { review_id: id } })
+    if (!result) {
+      return res.status(404).json({ message: 'Not found' })
+    }
+    return res.status(200).json(result)
+  } catch (error) {
+    if (error instanceof Error) {
+      return res.status(400).json({ message: error.message })
+    }
+    return res.status(500).json({ message: 'An error has occured' })
+  }
+}

--- a/routes/reviews/routes.js
+++ b/routes/reviews/routes.js
@@ -1,0 +1,25 @@
+import { Router } from 'express'
+import {
+  getAllReviews,
+  createReview,
+  getOneReview,
+  deleteReview,
+  updateReview,
+} from './controllers.js'
+
+export const router = Router()
+
+// Get reviews
+router.get('/reviews', getAllReviews)
+
+// Get one review
+router.get('/reviews/:id', getOneReview)
+
+// Create review
+router.post('/reviews', createReview)
+
+// Delete review
+router.delete('/reviews/:id', deleteReview)
+
+// Update review
+router.put('/reviews/:id', updateReview)

--- a/schemas/reviews.js
+++ b/schemas/reviews.js
@@ -1,0 +1,47 @@
+import Joi from 'joi'
+
+export const createReviewSchema = Joi.object({
+  service_id: Joi.number().integer().required().messages({
+    'number.base': 'Service ID must be a number.',
+    'number.integer': 'Service ID must be an integer.',
+    'any.required': 'Service ID is required.',
+  }),
+
+  client_id: Joi.number().integer().required().messages({
+    'number.base': 'Client ID must be a number.',
+    'number.integer': 'Client ID must be an integer.',
+    'any.required': 'Client ID is required.',
+  }),
+
+  rating: Joi.number().integer().min(1).max(5).required().messages({
+    'number.base': 'Rating must be a number.',
+    'number.integer': 'Rating must be an integer.',
+    'number.min': 'Rating must be at least 1.',
+    'number.max': 'Rating cannot exceed 5.',
+    'any.required': 'Rating is required.',
+  }),
+
+  comment: Joi.string().min(10).max(500).required().messages({
+    'string.base': 'Comment must be text.',
+    'string.min': 'Comment should be at least 10 characters long.',
+    'string.max': 'Comment cannot exceed 500 characters.',
+    'any.required': 'Comment is required.',
+  }),
+})
+
+export const updateReviewSchema = Joi.object({
+  rating: Joi.number().integer().min(1).max(5).required().messages({
+    'number.base': 'Rating must be a number.',
+    'number.integer': 'Rating must be an integer.',
+    'number.min': 'Rating must be at least 1.',
+    'number.max': 'Rating cannot exceed 5.',
+    'any.required': 'Rating is required.',
+  }),
+
+  comment: Joi.string().min(10).max(500).required().messages({
+    'string.base': 'Comment must be text.',
+    'string.min': 'Comment should be at least 10 characters long.',
+    'string.max': 'Comment cannot exceed 500 characters.',
+    'any.required': 'Comment is required.',
+  }),
+})

--- a/server.js
+++ b/server.js
@@ -7,6 +7,8 @@ import { router as users } from './routes/users/routes.js'
 import { router as profiles } from './routes/profiles/routes.js'
 import { router as login } from './routes/auth/login.js'
 import { router as verify } from './routes/auth/verify.js'
+import { router as reviews } from './routes/reviews/routes.js'
+
 import morgan from 'morgan'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -43,6 +45,7 @@ app.use(cors())
 app.use(express.static(path.join(__dirname, 'public')))
 app.use('/api', users)
 app.use('/api', profiles)
+app.use('/api', reviews)
 app.use('/api', login)
 app.use('/api', verify)
 


### PR DESCRIPTION
This commit introduces full CRUD functionality for reviews, including routes, controllers, and validation schemas. It adds endpoints to create, retrieve, update, and delete reviews, and integrates the new review routes into the main server.

## Summary by Sourcery

Add REST endpoints and validation for managing reviews and wire them into the main API.

New Features:
- Expose CRUD HTTP endpoints for reviews under the /api/reviews path.
- Introduce Joi-based validation schemas for creating and updating reviews payloads.

Enhancements:
- Integrate the new reviews router into the central Express server configuration.