### PR TITLE
feat(services): add CRUD endpoints for services resource

### DIFF
--- a/routes/services/controllers.js
+++ b/routes/services/controllers.js
@@ -1,0 +1,91 @@
+import { Service } from '../../models/service.js'
+import {
+  createServiceSchema,
+  updateServiceSchema,
+} from '../../schemas/services.js'
+
+// Get all Services
+export const getAllServices = async (_, res) => {
+  try {
+    const result = await Service.findAll()
+    return res.status(200).json(result)
+  } catch (error) {
+    if (error instanceof Error) {
+      return res.status(400).json({ message: error.message })
+    }
+    return res.status(500).json({ message: 'An error has occured' })
+  }
+}
+
+// Get One Service
+export const getOneService = async (req, res) => {
+  try {
+    const id = parseInt(req.params.id)
+    const result = await Service.findByPk(id)
+    return res.status(200).json(result)
+  } catch (error) {
+    if (error instanceof Error) {
+      return res.status(400).json({ message: error.message })
+    }
+    return res.status(500).json({ message: 'An error has occured' })
+  }
+}
+
+// Create Service
+export const createService = async (req, res) => {
+  try {
+    const body = req.body
+    const service = await createServiceSchema.validateAsync(body)
+    const result = await Service.create(service)
+    return res.status(200).json(result)
+  } catch (error) {
+    if (error instanceof Error) {
+      return res.status(400).json({ message: error.message })
+    }
+    return res.status(500).json({ message: 'An error has occured' })
+  }
+}
+
+// Update Service
+export const updateService = async (req, res) => {
+  try {
+    const id = parseInt(req.params.id)
+    const body = req.body
+    const serviceUpdate = await updateServiceSchema.validateAsync(body)
+
+    const result = await Service.findOne({ where: { service_id: id } })
+    if (!result) {
+      return res.status(404).json({ message: 'Not found' })
+    }
+
+    await Service.update(serviceUpdate, {
+      where: {
+        service_id: id,
+      },
+    })
+
+    return res.status(200).json({ message: 'Service updated' })
+  } catch (error) {
+    if (error instanceof Error) {
+      return res.status(400).json({ message: error.message })
+    }
+    return res.status(500).json({ message: 'An error has occured' })
+  }
+}
+
+// Delete Service
+export const deleteService = async (req, res) => {
+  try {
+    const id = parseInt(req.params.id)
+    const result = await Service.destroy({ where: { service_id: id } })
+    if (!result) {
+      return res.status(404).json({ message: 'Not found' })
+    }
+    return res.status(200).json(result)
+  } catch (error) {
+    if (error instanceof Error) {
+      return res.status(400).json({ message: error.message })
+    }
+    return res.status(500).json({ message: 'An error has occured' })
+  }
+}

--- a/routes/services/routes.js
+++ b/routes/services/routes.js
@@ -1,0 +1,25 @@
+import { Router } from 'express'
+import {
+  getAllServices,
+  createService,
+  getOneService,
+  deleteService,
+  updateService,
+} from './controllers.js'
+
+export const router = Router()
+
+// Get Services
+router.get('/services', getAllServices)
+
+// Get one review
+router.get('/services/:id', getOneService)
+
+// Create review
+router.post('/services', createService)
+
+// Update review
+router.put('/services/:id', updateService)
+
+// Delete review
+router.delete('/services/:id', deleteService)

--- a/schemas/services.js
+++ b/schemas/services.js
@@ -1,0 +1,71 @@
+import Joi from 'joi'
+
+export const createServiceSchema = Joi.object({
+  profile_id: Joi.number().integer().required().messages({
+    'number.base': 'Profile ID must be a number.',
+    'number.integer': 'Profile ID must be an integer.',
+    'any.required': 'Profile ID is required.',
+  }),
+
+  title: Joi.string().min(3).max(100).required().messages({
+    'string.base': 'Title must be text.',
+    'string.min': 'Title should be at least 3 characters long.',
+    'string.max': 'Title cannot exceed 100 characters.',
+    'any.required': 'Title is required.',
+  }),
+
+  description: Joi.string().min(10).max(1000).required().messages({
+    'string.base': 'Description must be text.',
+    'string.min': 'Description should be at least 10 characters long.',
+    'string.max': 'Description cannot exceed 1000 characters.',
+    'any.required': 'Description is required.',
+  }),
+
+  price_range: Joi.string()
+    .pattern(/^[£$€]?\d+(\–|-)[£$€]?\d+$/)
+    .required()
+    .messages({
+      'string.base': 'Price range must be text.',
+      'string.pattern.base':
+        'Price range must be in a valid format (e.g., £200-£500).',
+      'any.required': 'Price range is required.',
+    }),
+
+  availability: Joi.string().max(100).required().messages({
+    'string.base': 'Availability must be text.',
+    'string.max': 'Availability cannot exceed 100 characters.',
+    'any.required': 'Availability is required.',
+  }),
+})
+
+export const updateServiceSchema = Joi.object({
+  title: Joi.string().min(3).max(100).required().messages({
+    'string.base': 'Title must be text.',
+    'string.min': 'Title should be at least 3 characters long.',
+    'string.max': 'Title cannot exceed 100 characters.',
+    'any.required': 'Title is required.',
+  }),
+
+  description: Joi.string().min(10).max(1000).required().messages({
+    'string.base': 'Description must be text.',
+    'string.min': 'Description should be at least 10 characters long.',
+    'string.max': 'Description cannot exceed 1000 characters.',
+    'any.required': 'Description is required.',
+  }),
+
+  price_range: Joi.string()
+    .pattern(/^[£$€]?\d+(\–|-)[£$€]?\d+$/)
+    .required()
+    .messages({
+      'string.base': 'Price range must be text.',
+      'string.pattern.base':
+        'Price range must be in a valid format (e.g., £200–£500).',
+      'any.required': 'Price range is required.',
+    }),
+
+  availability: Joi.string().max(100).required().messages({
+    'string.base': 'Availability must be text.',
+    'string.max': 'Availability cannot exceed 100 characters.',
+    'any.required': 'Availability is required.',
+  }),
+})

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ import { router as profiles } from './routes/profiles/routes.js'
 import { router as login } from './routes/auth/login.js'
 import { router as verify } from './routes/auth/verify.js'
 import { router as reviews } from './routes/reviews/routes.js'
+import { router as services } from './routes/services/routes.js'
 
 import morgan from 'morgan'
 
@@ -46,6 +47,7 @@ app.use(express.static(path.join(__dirname, 'public')))
 app.use('/api', users)
 app.use('/api', profiles)
 app.use('/api', reviews)
+app.use('/api', services)
 app.use('/api', login)
 app.use('/api', verify)
 


### PR DESCRIPTION
This commit introduces the complete set of API endpoints for managing services.

- Adds controllers for creating, reading, updating, and deleting services.
- Defines the API routes under /api/services.
- Implements Joi validation schemas for service creation and updates.
- Integrates the new services router into the main server application.

## Summary by Sourcery

Add API support for managing services resources, including validation and routing integration into the main server.

New Features:
- Expose CRUD HTTP endpoints for the services resource under /api/services.
- Introduce Joi-based validation schemas for creating and updating services payloads.

Enhancements:
- Wire the new services router into the central Express application alongside existing API modules.