### PR TITLE
fix(profiles): correct location display and adjust review heading style

### DIFF
--- a/frontend/src/pages/profiles/ProfileDetails.jsx
+++ b/frontend/src/pages/profiles/ProfileDetails.jsx
@@ -79,7 +79,7 @@ export const ProfileDetails = () => {
                 <h3>{user.name}</h3>
                 <p className="text-capitalize">{user.role}</p>
                 <p>Email: {user.email} </p>
-                <p>{user.location}</p>
+                <p>{profile.location}</p>
               </Stack>
               <Stack>
                 <h4>About</h4>
@@ -111,7 +111,7 @@ export const ProfileDetails = () => {
         </Row>
       </Container>
       <Container className="py-5">
-        <h3>Reviews</h3>
+        <h3 className="mb-5">Reviews</h3>
         <Row>
           {reviews &&
             reviews.map((review) => {


### PR DESCRIPTION
The profile details page was incorrectly displaying the location of the currently logged-in user instead of the location of the profile being viewed. This has been corrected by changing the data source from the 'user' object to the 'profile' object.

Additionally, a bottom margin has been added to the 'Reviews' heading to improve the visual layout and spacing on the page.

## Summary by Sourcery

Fix profile details page to show the viewed profile's location and tweak the spacing of the Reviews section heading for improved layout.

Bug Fixes:
- Correct the displayed location on the profile details page to use the viewed profile rather than the logged-in user.

Enhancements:
- Increase spacing below the Reviews heading on the profile details page to improve visual layout.