### PR TITLE
feat(profile): add profile creation form

### DIFF
--- a/frontend/src/components/forms/ProfileForm.jsx
+++ b/frontend/src/components/forms/ProfileForm.jsx
@@ -1,0 +1,135 @@
+// import './LoginForm.css'
+import { useForm } from 'react-hook-form'
+import Button from 'react-bootstrap/Button'
+import Form from 'react-bootstrap/Form'
+import Stack from 'react-bootstrap/Stack'
+import { Link } from 'react-router-dom'
+
+import { useAuthStore } from '../../store/useAuthStore'
+import Alert from 'react-bootstrap/Alert'
+import { api as axios } from '../../api'
+import { useNavigate } from 'react-router-dom'
+import { isAxiosError } from 'axios'
+
+export const ProfileForm = ({ setShow }) => {
+  const navigate = useNavigate()
+  const formError = useAuthStore((state) => state.formError)
+  const setError = useAuthStore((state) => state.setError)
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm()
+
+  const onSubmit = async (profile) => {
+    console.log(profile)
+    setShow(false)
+    // try {
+    //   if (user.password !== user.confirmPassword)
+    //     throw new Error('Passwords must match')
+    //   const userData = {
+    //     name: user.name,
+    //     email: user.email,
+    //     password: user.password,
+    //   }
+    //   await axios.post('/users', userData)
+    //   navigate('/login')
+    // } catch (error) {
+    //   if (isAxiosError(error)) {
+    //     setError(await error.response.data.message)
+    //   } else {
+    //     setError(error.message || 'Passwords must match')
+    //   }
+    // } finally {
+    //   setTimeout(() => {
+    //     setError(null)
+    //   }, 5000)
+    // }
+  }
+
+  return (
+    <Stack>
+      <Form
+        className="mx-5 profile-form mt-5"
+        onSubmit={handleSubmit(onSubmit)}
+        style={{ maxWidth: 500 }}
+      >
+        <h5>Add profile details</h5>
+        {formError && <Alert variant="info">{formError}</Alert>}
+        <Form.Group className="mb-3" controlId="specialization">
+          <Form.Label>Specialization</Form.Label>
+          {errors.specialization?.type === 'required' && (
+            <small role="alert" className="text-danger d-block mt-2">
+              Specialization is required
+            </small>
+          )}
+          <Form.Control
+            placeholder="My Specialization"
+            type="text"
+            {...register('specialization', { required: true })}
+          />
+        </Form.Group>
+
+        <Form.Group className="mb-3" controlId="experience_years">
+          <Form.Label>Years Experience</Form.Label>
+          {errors.specialization?.type === 'required' && (
+            <small role="alert" className="text-danger d-block mt-2">
+              Experience is required
+            </small>
+          )}
+          <Form.Control
+            placeholder="8"
+            type="text"
+            {...register('experience_years', { required: true })}
+          />
+        </Form.Group>
+
+        <Form.Group className="mb-3" controlId="profile_photo_url">
+          <Form.Label>Photo URL</Form.Label>
+          {errors.profile_photo_url?.type === 'required' && (
+            <small role="alert" className="text-danger d-block mt-2">
+              Photo url is required
+            </small>
+          )}
+          <Form.Control
+            placeholder="https://example.com/images/profile42.jpg"
+            type="url"
+            {...register('profile_photo_url', { required: true })}
+          />
+        </Form.Group>
+
+        <Form.Group className="mb-3" controlId="location">
+          <Form.Label>Location</Form.Label>
+          {errors.location?.type === 'required' && (
+            <small role="alert" className="text-danger d-block mt-2">
+              Location is required
+            </small>
+          )}
+          <Form.Control
+            placeholder="London, UK"
+            type="text"
+            {...register('location', { required: true })}
+          />
+        </Form.Group>
+
+        <Form.Group className="mb-3" controlId="bio">
+          <Form.Label>Bio</Form.Label>
+          {errors.bio?.type === 'required' && (
+            <small role="alert" className="text-danger d-block mt-2">
+              Bio is required
+            </small>
+          )}
+          <Form.Control
+            placeholder="About me"
+            as="textarea"
+            {...register('bio', { required: true })}
+          />
+        </Form.Group>
+
+        <Button variant="primary" type="submit">
+          Submit
+        </Button>
+      </Form>
+    </Stack>
+  )
+}

--- a/frontend/src/pages/admin/MyAccount.jsx
+++ b/frontend/src/pages/admin/MyAccount.jsx
@@ -3,8 +3,11 @@ import { useAuthStore } from '../../store/useAuthStore'
 import { useFetchUsers } from '../../hooks/useFetchUsers'
 import Button from 'react-bootstrap/esm/Button'
 import { api as axios } from '../../api'
+import { ProfileForm } from '../../components/forms/ProfileForm'
+import { useState } from 'react'
 
 export const MyAccount = () => {
+  const [show, setShow] = useState(false)
   const user = useAuthStore((state) => state.user)
   const setAuth = useAuthStore((state) => state.setAuth)
   const { loading, data, error } = useFetchUsers(user.user_id)
@@ -48,12 +51,22 @@ export const MyAccount = () => {
             </p>
           </>
         )}
-        {data.role === 'lawyer' && !data.Profile && (
-          <Button>Create Profile</Button>
-        )}
-        {data.role === 'accountant' && !data.Profile && (
-          <Button>Create Profile</Button>
-        )}
+        {show && <ProfileForm setShow={setShow} />}
+        {data.role === 'lawyer' &&
+          !data.Profile &&
+          (show ? (
+            ''
+          ) : (
+            <Button onClick={() => setShow(true)}>Create Profile</Button>
+          ))}
+
+        {data.role === 'accountant' &&
+          !data.Profile &&
+          (show ? (
+            ''
+          ) : (
+            <Button onClick={() => setShow(true)}>Create Profile</Button>
+          ))}
 
         {user.pending_role && (
           <p className="text-info">Request is pending...</p>

--- a/server.js
+++ b/server.js
@@ -29,7 +29,7 @@ const connect = async () => {
 
 const syncDb = async () => {
   try {
-    await sequelize.sync({ force: false, alter: true })
+    await sequelize.sync({ force: false, alter: false })
     console.log('Database synced successfully.')
   } catch (error) {
     console.error('Error syncing database:', error)


### PR DESCRIPTION
- Creates a new  component with fields for specialization, experience, photo URL, location, and bio.
- Integrates the form into the  page, making it available to users with 'lawyer' or 'accountant' roles who have not yet created a profile.
- A 'Create Profile' button is now displayed, which toggles the visibility of the new form.
- Adjusts the Sequelize sync setting to  to prevent automatic and potentially destructive database schema changes.

## Summary by Sourcery

Add a profile creation form for eligible users and disable automatic database schema alterations during Sequelize sync.

New Features:
- Introduce a ProfileForm component for capturing specialization, experience, photo URL, location, and bio.
- Expose a Create Profile flow on the MyAccount page for lawyer and accountant users without an existing profile, toggled via a button.

Enhancements:
- Update MyAccount page UI to conditionally render the profile creation form and button based on user role and profile state.

Build:
- Change Sequelize sync configuration to disable automatic schema alteration (alter: false) to avoid unintended database changes.