### PR TITLE
feat(profile): allow users to create and view their profile

### DIFF
--- a/frontend/src/components/forms/ProfileForm.jsx
+++ b/frontend/src/components/forms/ProfileForm.jsx
@@ -3,48 +3,42 @@ import { useForm } from 'react-hook-form'
 import Button from 'react-bootstrap/Button'
 import Form from 'react-bootstrap/Form'
 import Stack from 'react-bootstrap/Stack'
-import { Link } from 'react-router-dom'
-
 import { useAuthStore } from '../../store/useAuthStore'
 import Alert from 'react-bootstrap/Alert'
 import { api as axios } from '../../api'
-import { useNavigate } from 'react-router-dom'
 import { isAxiosError } from 'axios'
 
-export const ProfileForm = ({ setShow }) => {
-  const navigate = useNavigate()
+export const ProfileForm = ({ setShow, refetch }) => {
   const formError = useAuthStore((state) => state.formError)
   const setError = useAuthStore((state) => state.setError)
+  const user = useAuthStore((state) => state.user)
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm()
 
-  const onSubmit = async (profile) => {
-    console.log(profile)
-    setShow(false)
-    // try {
-    //   if (user.password !== user.confirmPassword)
-    //     throw new Error('Passwords must match')
-    //   const userData = {
-    //     name: user.name,
-    //     email: user.email,
-    //     password: user.password,
-    //   }
-    //   await axios.post('/users', userData)
-    //   navigate('/login')
-    // } catch (error) {
-    //   if (isAxiosError(error)) {
-    //     setError(await error.response.data.message)
-    //   } else {
-    //     setError(error.message || 'Passwords must match')
-    //   }
-    // } finally {
-    //   setTimeout(() => {
-    //     setError(null)
-    //   }, 5000)
-    // }
+  const onSubmit = async (profileData) => {
+    try {
+      const token = localStorage.getItem('authToken')
+      await axios.post(
+        '/profiles',
+        { ...profileData, user_id: user.user_id },
+        { headers: { Authorization: 'Bearer ' + token } }
+      )
+      setShow(false)
+      refetch()
+    } catch (error) {
+      if (isAxiosError(error)) {
+        setError(await error.response.data.message)
+      } else {
+        setError(error.message || 'Error creating user profile')
+      }
+    } finally {
+      setTimeout(() => {
+        setError(null)
+      }, 5000)
+    }
   }
 
   return (

--- a/frontend/src/hooks/useFetchUsers.js
+++ b/frontend/src/hooks/useFetchUsers.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { api as axios } from '../api'
 import { isAxiosError } from 'axios'
+import { useCallback } from 'react'
 
 export const useFetchUsers = (id = null) => {
   const [data, setData] = useState([])
@@ -10,11 +11,7 @@ export const useFetchUsers = (id = null) => {
   let url = '/users'
   if (id) url = `/users/${id}`
 
-  useEffect(() => {
-    getUsers()
-  }, [])
-
-  const getUsers = async () => {
+  const getUsers = useCallback(async () => {
     try {
       const response = await axios.get(url)
       const usersData = await response.data
@@ -31,7 +28,13 @@ export const useFetchUsers = (id = null) => {
     } finally {
       setLoading(false)
     }
-  }
+  }, [url])
 
-  return { data, error, loading }
+  useEffect(() => {
+    getUsers()
+  }, [getUsers])
+
+  const refetch = getUsers
+
+  return { data, error, loading, refetch }
 }

--- a/frontend/src/pages/admin/MyAccount.jsx
+++ b/frontend/src/pages/admin/MyAccount.jsx
@@ -10,7 +10,7 @@ export const MyAccount = () => {
   const [show, setShow] = useState(false)
   const user = useAuthStore((state) => state.user)
   const setAuth = useAuthStore((state) => state.setAuth)
-  const { loading, data, error } = useFetchUsers(user.user_id)
+  const { loading, data, error, refetch } = useFetchUsers(user.user_id)
 
   if (loading) return <CSpinner color="primary" />
   if (error) return <p>{error.message}</p>
@@ -36,6 +36,12 @@ export const MyAccount = () => {
           <strong>Name:</strong> {data.name}
         </p>
         <p>
+          <strong>Specialization:</strong> {data.Profile.specialization}
+        </p>
+        <p>
+          <strong>Location:</strong> {data.Profile.location}
+        </p>
+        <p>
           <strong>Email:</strong> {data.email}
         </p>
         <p>
@@ -51,7 +57,7 @@ export const MyAccount = () => {
             </p>
           </>
         )}
-        {show && <ProfileForm setShow={setShow} />}
+        {show && <ProfileForm setShow={setShow} refetch={refetch} />}
         {data.role === 'lawyer' &&
           !data.Profile &&
           (show ? (


### PR DESCRIPTION
This commit implements the functionality for users to create their profile from the 'My Account' page and view the details once created.

- The  is updated to handle the submission of profile data to the backend.
- The  hook now exposes a  function to allow data to be re-fetched after a profile is created.
- The  page is updated to display the user's profile information (specialization and location) and to trigger a data refetch after profile creation, ensuring the UI updates automatically.

## Summary by Sourcery

Enable profile creation and display from the My Account page and support refetching user data after profile updates.

New Features:
- Allow users to submit profile data that is persisted via the profiles API endpoint.
- Display a user's specialization and location from their profile on the My Account page.

Enhancements:
- Expose a refetch function from the useFetchUsers hook to allow on-demand reloading of user data after updates.